### PR TITLE
chore: update feeHandlers

### DIFF
--- a/docs/08-resources/01-environments/03-testnet/index.md
+++ b/docs/08-resources/01-environments/03-testnet/index.md
@@ -28,7 +28,6 @@ The following section details Sygma's testnet deployments, including both MPC an
     - [Base Sepolia](#base-sepolia)
     - [Amoy](#amoy)
     - [B3 Sepolia](#b3-sepolia)
-    - [Bison](#bison)
 - [Registered Resources](#registered-resources)
 - [Fee Schemes](#fee-schemes)
 - [Sygma Explorer](#sygma-explorer)
@@ -55,9 +54,11 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                       | MPC Address                                                                                                                   | Spectre Address                                                                                                               |
 |--------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | Bridge                         | [0x4CF326d3817558038D1DEF9e76b727202c3E8492](https://sepolia.etherscan.io/address/0x4CF326d3817558038D1DEF9e76b727202c3E8492) | [0x60e3fd2148f3D6934521a00a0Cf318cB1194e072](https://sepolia.etherscan.io/address/0x60e3fd2148f3D6934521a00a0Cf318cB1194e072) |
-| Fee Router                     | [0x9D45e9bE1E70735Ee78052717107d5dc59C1EaCE](https://sepolia.etherscan.io/address/0x9D45e9bE1E70735Ee78052717107d5dc59C1EaCE) | [0xC2C26789671ec5e1542308Ee38faE4A640bCc03e](https://sepolia.etherscan.io/address/0xC2C26789671ec5e1542308Ee38faE4A640bCc03e) |
-| Fixed Fee Handler              | [0xDcBA3f691eF406415556C802163C265Db56208cF](https://sepolia.etherscan.io/address/0xDcBA3f691eF406415556C802163C265Db56208cF) | [0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C](https://sepolia.etherscan.io/address/0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C) |
-| Percentage Fee Handler         | [0x2e77dEa116117eCF44a427064260D16D488ccff2](https://sepolia.etherscan.io/address/0x2e77dEa116117eCF44a427064260D16D488ccff2) | [0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0](https://sepolia.etherscan.io/address/0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0) |
+| Fee Router                     | [0xD277478b4684Ed8594d5eb5B228AA7aDbA59df43](https://sepolia.etherscan.io/address/0xD277478b4684Ed8594d5eb5B228AA7aDbA59df43) | [0xC2C26789671ec5e1542308Ee38faE4A640bCc03e](https://sepolia.etherscan.io/address/0xC2C26789671ec5e1542308Ee38faE4A640bCc03e) |
+| Fixed Fee Handler              | [0x356B7B3C25355325CcBFBCF00a82895F93f086b7](https://sepolia.etherscan.io/address/0x356B7B3C25355325CcBFBCF00a82895F93f086b7) | [0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C](https://sepolia.etherscan.io/address/0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C) |
+| Percentage Fee Handler         | [0xDDa14370765696cD64bA93b974a934FF18A278e2](https://sepolia.etherscan.io/address/0xDDa14370765696cD64bA93b974a934FF18A278e2) | [0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0](https://sepolia.etherscan.io/address/0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0) |
+| Dynamic Fee Handler         | [0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37](https://sepolia.etherscan.io/address/0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37) |
+| Dynamic Fee Handler         | [0x52C09318436d729c212B582A0b2Aba2952da0a05](https://sepolia.etherscan.io/address/0x52C09318436d729c212B582A0b2Aba2952da0a05) |
 | ERC-20 Handler                 | [0xa65387feCb172ffF8A0aabA323A10c63757BBFA6](https://sepolia.etherscan.io/address/0xa65387feCb172ffF8A0aabA323A10c63757BBFA6) | [0x65Ce12864941F56D3665bb0d97D803E81a1d09a0](https://sepolia.etherscan.io/address/0x65Ce12864941F56D3665bb0d97D803E81a1d09a0) |
 | ERC-721 Handler                | [0x669F52487ffA6f9aBf722082f735537A98Ec0E4b](https://sepolia.etherscan.io/address/0x669F52487ffA6f9aBf722082f735537A98Ec0E4b) |                                                                                                                               |
 | ERC-1155 Handler               | [0x65903772866e538e6ffc001dd0c7665e356eb6d8](https://sepolia.etherscan.io/address/0x65903772866e538e6ffc001dd0c7665e356eb6d8) |                                                                                                                               |
@@ -74,10 +75,10 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0x816bb9E810b6b97840F6818bF21Fa25DD7364132](https://explorer.cronos.org/testnet/address/0x816bb9E810b6b97840F6818bF21Fa25DD7364132) |
-| Fee Router                        | [0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746](https://explorer.cronos.org/testnet/address/0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746) |
-| Fixed Fee Handler                 | [0x8eDab7563C618a3F1e5021677640565468C706d8](https://explorer.cronos.org/testnet/address/0x8eDab7563C618a3F1e5021677640565468C706d8) |
-| Percentage Fee Handler            | [0x26545905a3a63B9ffB37926e909a827bDd088512](https://explorer.cronos.org/testnet/address/0x26545905a3a63B9ffB37926e909a827bDd088512) |
-| ERC-20 Handler                    | [0x39D1Aea5F01138940F19A15049E2073D4df1dc9E](https://explorer.cronos.org/testnet/address/0x39D1Aea5F01138940F19A15049E2073D4df1dc9E) |
+| Fee Router                        | [0xFaa9214b2bb90222c4f5A2DAbBB61fC945CDFD42](https://explorer.cronos.org/testnet/address/0xFaa9214b2bb90222c4f5A2DAbBB61fC945CDFD42) |
+| Fixed Fee Handler                 | [0x1afc317C3C8578274B557a022aD79e073ef6EBF7](https://explorer.cronos.org/testnet/address/0x1afc317C3C8578274B557a022aD79e073ef6EBF7) |
+| Percentage Fee Handler            | [0xC5244700904c987E5441F568440ed5c3b7233559](https://explorer.cronos.org/testnet/address/0xC5244700904c987E5441F568440ed5c3b7233559) |
+| ERC-20 Handler                    | [0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7](https://explorer.cronos.org/testnet/address/0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7) |
 | ERC-721 Handler                   | [0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a](https://explorer.cronos.org/testnet/address/0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a) |
 | ERC-1155 Handler                  | [0x2d92a0aa3ea19da735514ea542438345ef09cb60](https://explorer.cronos.org/testnet/address/0x2d92a0aa3ea19da735514ea542438345ef09cb60) |
 | Permissionless Generic Handler    | [0x3CBbC542d10CD037cafb1632B29B5B0F59B08A48](https://explorer.cronos.org/testnet/address/0x3CBbC542d10CD037cafb1632B29B5B0F59B08A48) |
@@ -87,11 +88,11 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 
 | Contract                       | MPC Address                                                                                                                   | Spectre Address                                                                                                               |
 |--------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| Bridge                         | [0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78](https://holesky.etherscan.io/address/0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78) | [0x3DA376947B760836905a0407588C606D1020C4f3](https://holesky.etherscan.io/address/0x3DA376947B760836905a0407588C606D1020C4f3) |
-| Fee Router                     | [0x5626A5a7b65E3d851c693AC583068e75853fE0C8](https://holesky.etherscan.io/address/0x5626A5a7b65E3d851c693AC583068e75853fE0C8) | [0x48512523Bb2634467292dd7776313916425F4c8a](https://holesky.etherscan.io/address/0x48512523Bb2634467292dd7776313916425F4c8a) |
-| Fixed Fee Handler              | [0xEE7946aE5f7287a39Bc67207868EDD4a95f96795](https://holesky.etherscan.io/address/0xEE7946aE5f7287a39Bc67207868EDD4a95f96795) | [0x51b9DcAcB395B00857C815aDb89D20175cBb4A58](https://holesky.etherscan.io/address/0x51b9DcAcB395B00857C815aDb89D20175cBb4A58) |
-| Percentage Fee Handler         | [0x9535484111383531BB9D6922B309Bf316Cec9A19](https://holesky.etherscan.io/address/0x9535484111383531BB9D6922B309Bf316Cec9A19) | [0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1](https://holesky.etherscan.io/address/0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1) |
-| ERC-20 Handler                 | [0xEeFBd08769Ab1e369a04a17180E91E4549938d4c](https://holesky.etherscan.io/address/0xEeFBd08769Ab1e369a04a17180E91E4549938d4c) | [0x96e0cBCb653448a6AE76C2f4041eC6D73127585a](https://holesky.etherscan.io/address/0x96e0cBCb653448a6AE76C2f4041eC6D73127585a) |
+| Bridge                         | [0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a](https://holesky.etherscan.io/address/0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a) | [0x3DA376947B760836905a0407588C606D1020C4f3](https://holesky.etherscan.io/address/0x3DA376947B760836905a0407588C606D1020C4f3) |
+| Fee Router                     | [0xfc8fE2bC5C780ef8cA28dda09751ef69BdDA53Cb](https://holesky.etherscan.io/address/0xfc8fE2bC5C780ef8cA28dda09751ef69BdDA53Cb) | [0x48512523Bb2634467292dd7776313916425F4c8a](https://holesky.etherscan.io/address/0x48512523Bb2634467292dd7776313916425F4c8a) |
+| Fixed Fee Handler              | [0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef](https://holesky.etherscan.io/address/0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef) | [0x51b9DcAcB395B00857C815aDb89D20175cBb4A58](https://holesky.etherscan.io/address/0x51b9DcAcB395B00857C815aDb89D20175cBb4A58) |
+| Percentage Fee Handler         | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://holesky.etherscan.io/address/0xa477963806167acB38830Ea91B081a3de47B6ce9) | [0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1](https://holesky.etherscan.io/address/0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1) |
+| ERC-20 Handler                 | [0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F](https://holesky.etherscan.io/address/0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F) | [0x96e0cBCb653448a6AE76C2f4041eC6D73127585a](https://holesky.etherscan.io/address/0x96e0cBCb653448a6AE76C2f4041eC6D73127585a) |
 | ERC-721 Handler                |                                                                                                                               |                                                                                                                               |
 | Permissionless Generic Handler | [0xc1154781Fa12a845aCaf276Bf2030040Ba9DAec8](https://holesky.etherscan.io/address/0xc1154781Fa12a845aCaf276Bf2030040Ba9DAec8) | [0x347BfeA6B3E929d91caE8e0AfB5DE97d3574AB45](https://holesky.etherscan.io/address/0x347BfeA6B3E929d91caE8e0AfB5DE97d3574AB45) |
 | Storage (GMP testing contract) | [0x58476c75b48c86c05ccad9ae82ac76145bc9119d](https://holesky.etherscan.io/address/0x58476c75b48c86c05ccad9ae82ac76145bc9119d) |                                                                                                                               |
@@ -106,9 +107,9 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0xFB2530Fb3f5801aD35ccd6fdA29715D9330b7F9f](https://sepolia.arbiscan.io/address/0xFB2530Fb3f5801aD35ccd6fdA29715D9330b7F9f) |
-| Fee Router                        | [0x723366b1Cfff44ebddCB1E1FE569a439363E3B80](https://sepolia.arbiscan.io/address/0x723366b1Cfff44ebddCB1E1FE569a439363E3B80) |
-| Fixed Fee Handler                 | [0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78](https://sepolia.arbiscan.io/address/0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78) |
-| Percentage Fee Handler            | [0xEeFBd08769Ab1e369a04a17180E91E4549938d4c](https://sepolia.arbiscan.io/address/0xEeFBd08769Ab1e369a04a17180E91E4549938d4c) |
+| Fee Router                        | [0x2CD3f725BF9aa446FBD38e2A1A4787a40eEA2286](https://sepolia.arbiscan.io/address/0x2CD3f725BF9aa446FBD38e2A1A4787a40eEA2286) |
+| Fixed Fee Handler                 | [0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a](https://sepolia.arbiscan.io/address/0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a) |
+| Percentage Fee Handler            | [0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F](https://sepolia.arbiscan.io/address/0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F) |
 | ERC-20 Handler                    | [0x5AF405550De00b38cAC1ED7276d0A09114831bCB](https://sepolia.arbiscan.io/address/0x5AF405550De00b38cAC1ED7276d0A09114831bCB) |
 | ERC-721 Handler                   |  |
 | Permissionless Generic Handler    | [0x5ffB6Dc54221371CcBDb9850A283488e12aDf97D](https://sepolia.arbiscan.io/address/0x5ffB6Dc54221371CcBDb9850A283488e12aDf97D) |
@@ -119,9 +120,9 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0x668fad90DeAd0F8f04346A735875b62eF9c65f0B](https://gnosis-chiado.blockscout.com/address/0x668fad90DeAd0F8f04346A735875b62eF9c65f0B) |
-| Fee Router                        | [0x3F22ae1e689561Fb36013e40b464482EFA8ec465](https://gnosis-chiado.blockscout.com/address/0x3F22ae1e689561Fb36013e40b464482EFA8ec465) |
-| Fixed Fee Handler                 | [0x9F5efb442d6F24704dB85569876D9c0CA65aed40](https://gnosis-chiado.blockscout.com/address/0x9F5efb442d6F24704dB85569876D9c0CA65aed40) |
-| Percentage Fee Handler            | [0x95735f49808502C31375F49583c4DFc26cccF0e5](https://gnosis-chiado.blockscout.com/address/0x95735f49808502C31375F49583c4DFc26cccF0e5) |
+| Fee Router                        | [0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E](https://gnosis-chiado.blockscout.com/address/0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E) |
+| Fixed Fee Handler                 | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://gnosis-chiado.blockscout.com/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a) |
+| Percentage Fee Handler            | [0xA6Cd2A4c41946fAADACf88a87A50997B04abE557](https://gnosis-chiado.blockscout.com/address/0xA6Cd2A4c41946fAADACf88a87A50997B04abE557) |
 | ERC-20 Handler                    | [0xb947F89269F0cF54CC721BcDE298a46930f3418b](https://gnosis-chiado.blockscout.com/address/0xb947F89269F0cF54CC721BcDE298a46930f3418b) |
 | Permissionless Generic Handler    | [0xe4B86b1B07bBdB0C47940b9B3bD4954A0deAdaBE](https://gnosis-chiado.blockscout.com/address/0xe4B86b1B07bBdB0C47940b9B3bD4954A0deAdaBE) |
 | Storage (GMP testing contract)    | [0x38ee9a4590035fc9506600f4d5c3f75fc8d15406](https://gnosis-chiado.blockscout.com/address/0x38ee9a4590035fc9506600f4d5c3f75fc8d15406) |
@@ -131,9 +132,9 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F](https://sepolia.basescan.org/address/0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F) |
-| Fee Router                        | [0x772e242e6c312f6eF6255d8F35921e7A30D018BA](https://sepolia.basescan.org/address/0x772e242e6c312f6eF6255d8F35921e7A30D018BA) |
-| Fixed Fee Handler                 | [0xde937016D67811f08D93ee54093ea686C21d211C](https://sepolia.basescan.org/address/0xde937016D67811f08D93ee54093ea686C21d211C) |
-| Percentage Fee Handler            | [0x4430E5D4447Df0FC25adCafEb8b5E49d38B56e21](https://sepolia.basescan.org/address/0x4430E5D4447Df0FC25adCafEb8b5E49d38B56e21) |
+| Fee Router                        | [0x241a1617a0C73373110F868C07e38679B1Ec4950](https://sepolia.basescan.org/address/0x241a1617a0C73373110F868C07e38679B1Ec4950) |
+| Fixed Fee Handler                 | [0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a](https://sepolia.basescan.org/address/0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a) |
+| Percentage Fee Handler            | [0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746](https://sepolia.basescan.org/address/0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746) |
 | ERC-20 Handler                    | [0x72a588B76025d552B239532C31fB7D5Cc80A3e41](https://sepolia.basescan.org/address/0x72a588B76025d552B239532C31fB7D5Cc80A3e41) |
 | Permissionless Generic Handler    | [0x7f4e1E62A0Abd4A381254335CeF5770F74b3E22E](https://sepolia.basescan.org/address/0x7f4e1E62A0Abd4A381254335CeF5770F74b3E22E) |
 | Permissionless Generic Handler    | [0xfd69bbfcCbfc832C56Ca1490df48B4baF3DfD376](https://sepolia.basescan.org/address/0xfd69bbfcCbfc832C56Ca1490df48B4baF3DfD376) |
@@ -144,9 +145,9 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e](https://www.oklink.com/amoy/0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e) |
-| Fee Router                        | [0x055CEe6D441f0c913D863776356C12FfA2FCDc47](https://www.oklink.com/amoy/0x055CEe6D441f0c913D863776356C12FfA2FCDc47) |
-| Fixed Fee Handler                 | [0x43E3A09C5Db24130b94f415fD11bac4b1d44A6A3](https://www.oklink.com/amoy/0x43E3A09C5Db24130b94f415fD11bac4b1d44A6A3) |
-| Percentage Fee Handler            | [0xcdc03289407b570e434D4BA17B3481CF6B02f369](https://www.oklink.com/amoy/0xcdc03289407b570e434D4BA17B3481CF6B02f369) |
+| Fee Router                        | [0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6](https://www.oklink.com/amoy/0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6) |
+| Fixed Fee Handler                 | [0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7](https://www.oklink.com/amoy/0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7) |
+| Percentage Fee Handler            | [0x2E3d3b2535785341584D17840F59dc0370b3504D](https://www.oklink.com/amoy/0x2E3d3b2535785341584D17840F59dc0370b3504D) |
 | ERC-20 Handler                    | [0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af](https://www.oklink.com/amoy/0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af) |
 | Permissionless Generic Handler    | [0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7](https://www.oklink.com/amoy/0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7) |
 | Permissionless Generic Handler    | [0x1F932B2582c52f939DCfb367A3A42f8A95f66782](https://www.oklink.com/amoy/0x1F932B2582c52f939DCfb367A3A42f8A95f66782) |
@@ -156,23 +157,13 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0xFF92C3C393B22F9d26e5732F2601EaC04094880F](https://sepolia.explorer.b3.fun/address/0xFF92C3C393B22F9d26e5732F2601EaC04094880F) |
-| Fee Router                        | [0x837F6005187b0Ce30451b464a0C6ae77F1aC94F7](https://sepolia.explorer.b3.fun/address/0x837F6005187b0Ce30451b464a0C6ae77F1aC94F7) |
-| Fixed Fee Handler                 | [0x27284B791992a40D18197087477304368Ac67Fcb](https://sepolia.explorer.b3.fun/address/0x27284B791992a40D18197087477304368Ac67Fcb) |
-| Percentage Fee Handler            | [0x14d1cA88277E13B5615C2C727415a1B94E90264F](https://sepolia.explorer.b3.fun/address/0x14d1cA88277E13B5615C2C727415a1B94E90264F) |
+| Fee Router                        | [0xA56419ECdb71acE442a6FbfC8E50c5F993667938](https://sepolia.explorer.b3.fun/address/0xA56419ECdb71acE442a6FbfC8E50c5F993667938) |
+| Fixed Fee Handler                 | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://sepolia.explorer.b3.fun/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a) |
+| Percentage Fee Handler            | [0xA6Cd2A4c41946fAADACf88a87A50997B04abE557](https://sepolia.explorer.b3.fun/address/0xA6Cd2A4c41946fAADACf88a87A50997B04abE557) |
 | ERC-20 Handler                    | [0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E](https://sepolia.explorer.b3.fun/address/0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E) |
-| Permissionless Generic Handler    | [0x39D1Aea5F01138940F19A15049E2073D4df1dc9E](https://sepolia.explorer.b3.fun/address/0x39D1Aea5F01138940F19A15049E2073D4df1dc9E) |
+| Permissionless Generic Handler    | [0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7](https://sepolia.explorer.b3.fun/address/0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7) |
 | Storage (GMP testing contract)    |  |
 
-#### Bison
-| Contract                          | Address                                    |
-| --------------------------------- | ------------------------------------------ |
-| Bridge                            | 0x7e28f84A21cf0349165dD4f0590B1D28b71c6087 |
-| Fee Router                        | 0x9CADaEBd6B67E424E0Cbc67Da1aF7cF991cFCb1E |
-| Fixed Fee Handler                 | 0x9b2Ac30252AADaD5DfBa81B65aA055153B0c796a |
-| Percentage Fee Handler            | 0x7a26BAC81b453E4d6407b8e3fD7989cF650dCABd |
-| ERC-20 Handler                    | 0x564ba4645aEB9F91eCfd0B0FE47B273C34F28943 |
-| Permissionless Generic Handler    | 0x669F52487ffA6f9aBf722082f735537A98Ec0E4b |
-| Storage (GMP testing contract)    |  |
 
 ## Registered Resources
 
@@ -188,6 +179,8 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Resource ID              | 0x0000000000000000000000000000000000000000000000000000000000000300                                                                   |
 | Sepolia Contract Address | [0x7d58589b6C1Ba455c4060a3563b9a0d447Bef9af](https://sepolia.etherscan.io/address/0x7d58589b6C1Ba455c4060a3563b9a0d447Bef9af)        |
 | Cronos Contract Address  | [0x2938ed97ef9d897dac7b21c48e045f34a3a02846](https://explorer.cronos.org/testnet/address/0x2938ed97ef9d897dac7b21c48e045f34a3a02846) |
+| Amoy Contract Address    | [0x245466D2175bcED0A1ad1ce804C8F724D7050e85](https://www.oklink.com/amoy/address/0x245466d2175bced0a1ad1ce804c8f724d7050e85)         |
+
 
 **Phala**
 
@@ -199,25 +192,7 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Registered Handler       | ERC20Handler                                                                                                                 |
 | Bridging Strategy        | Lock/Release                                                                                                                 |
 | Resource ID              | 0x0000000000000000000000000000000000000000000000000000000000001000                                                           |
-| Sepolia Contract Address | N/A                                                                                                                          |
-
-**Permissionless generic message (MAX_FEE = 1 million)**
-
-| Details                           | Information                                                        |
-| --------------------------------- | ------------------------------------------------------------------ |
-| Type                              | Generic                                                            |
-| Registered Fee Handler            | BasicFeeHandler                                                    |
-| Registered Handler                | PermissionlessGenericHandler                                       |
-| Bridging Strategy                 | GMP                                                                |
-| Resource ID                       | 0x0000000000000000000000000000000000000000000000000000000000000500 |
-| Sepolia Contract Address          | N/A                                                                |
-| Cronos-Testnet Contract Address   | N/A                                                                |
-| Holesky Contract Address          | N/A                                                                |
-| Arbitrum-Sepolia Contract Address | N/A                                                                |
-| Base-sepolia Contract Address     | N/A                                                                |
-| Amoy Contract Address     | N/A                                                                |
-| B3 Sepolia Contract Address     | N/A                                                                |
-| Bison Contract Address     | N/A                                                                |
+| Sepolia Contract Address | [0xAE3283fb214cDb14884039Df09B7895773e68eFA](https://sepolia.etherscan.io/address/0xAE3283fb214cDb14884039Df09B7895773e68eFA)|
 
 **Permissionless generic message (MAX_FEE = 15 million)**
 
@@ -272,28 +247,28 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Registered Handler            | ERC20Handler                                                                                                                       |
 | Bridging Strategy             | Lock/Release                                                                                                                            |
 | Resource ID                   | 0x0000000000000000000000000000000000000000000000000000000000000700                                                                   |
-| Bison Contract Address      | 0x53B8C30a0C51DDda196d62DA40dF810cb8f87859    |
+| Sepolia Contract Address      | [0xc3cb14a020319f479ff164485008896a853dc8ca](https://sepolia.etherscan.io/address/0xc3cb14a020319f479ff164485008896a853dc8ca)        |
+| Holsky Contract Address       | [0x34d4fb8c45060143d39b7526c2b645d351af85a5](https://holesky.etherscan.io/address/0x34d4fb8c45060143d39b7526c2b645d351af85a5)         |
+
 
 ## Fee Schemes
 
 | Network Name                    | Handler Address                                                                                                                      | Fee Type   | Fee Percent/Amount | Gas Amount |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ------------------ | ---------- |
-| Sepolia Fixed                   | N/A                                                                                                                                  | Fixed fee  | 0.001 ETH          |            |
-| Sepolia Percentage-based        | [0x2e77dEa116117eCF44a427064260D16D488ccff2](https://sepolia.etherscan.io/address/0x2e77dEa116117eCF44a427064260D16D488ccff2)        | Percentage | 10 BPS (or 0.1%)   |            |
-| Cronos-Testnet Fixed            | [0x8eDab7563C618a3F1e5021677640565468C706d8](https://explorer.cronos.org/testnet/address/0x8eDab7563C618a3F1e5021677640565468C706d8) | Fixed fee  | 0.001 ETH          |            |
-| Cronos-Testnet Percentage-based | [0x26545905a3a63B9ffB37926e909a827bDd088512](https://explorer.cronos.org/testnet/address/0x26545905a3a63B9ffB37926e909a827bDd088512) | Percentage | 1 BPS (or 0.01%)   |            |
-| Holesky Fixed                   | [0xEE7946aE5f7287a39Bc67207868EDD4a95f96795](https://holesky.etherscan.io/address/0xEE7946aE5f7287a39Bc67207868EDD4a95f96795)        | Fixed fee  | 0.001 ETH          |            |
-| Holesky Percentage-based        | [0x9535484111383531BB9D6922B309Bf316Cec9A19](https://holesky.etherscan.io/address/0x9535484111383531BB9D6922B309Bf316Cec9A19)        | Percentage | 1 BPS (or 0.01%)   |            |
-| Arbitrum-Sepolia Fixed          | [0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78](https://sepolia.arbiscan.io/address/0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78)         | Fixed fee  | 0.001 ETH          |            |
-| Gnosis-Chiado Fixed             | [0x9F5efb442d6F24704dB85569876D9c0CA65aed40](https://gnosis-chiado.blockscout.com/address/0x9F5efb442d6F24704dB85569876D9c0CA65aed40)| Fixed fee  | 0.001 xDAI         |            |
-| Base sepolia Fixed              | [0xde937016D67811f08D93ee54093ea686C21d211C](https://sepolia.basescan.org/address/0xde937016D67811f08D93ee54093ea686C21d211C)        | Fixed fee  | 0.001 ETH          |            |
-| Base sepolia Percentage-based   | [0x9535484111383531BB9D6922B309Bf316Cec9A19](https://sepolia.basescan.org/address/0x4430E5D4447Df0FC25adCafEb8b5E49d38B56e21)        | Percentage | 1 BPS (or 0.01%)   |            |
-| Amoy Fixed              | [0x43E3A09C5Db24130b94f415fD11bac4b1d44A6A3](https://www.oklink.com/amoy/address/0x43E3A09C5Db24130b94f415fD11bac4b1d44A6A3)        | Fixed fee  | 0.001 ETH          |            |
-| Amoy Percentage-based   | [0xcdc03289407b570e434D4BA17B3481CF6B02f369](https://www.oklink.com/amoy/address/0xcdc03289407b570e434D4BA17B3481CF6B02f369)        | Percentage | 1 BPS (or 0.01%)   |            |
-| B3 Sepolia Fixed   | [0x27284B791992a40D18197087477304368Ac67Fcb](https://sepolia.explorer.b3.fun/address/0x27284B791992a40D18197087477304368Ac67Fcb)         | Fixed fee  | 0.001 ETH          |            |
-| B3 Sepolia Percentage-based   | [0x14d1cA88277E13B5615C2C727415a1B94E90264F](https://sepolia.explorer.b3.fun/address/0x14d1cA88277E13B5615C2C727415a1B94E90264F)        | Percentage | 1 BPS (or 0.01%)   |            |
-| Bison Fixed   | 0x9b2Ac30252AADaD5DfBa81B65aA055153B0c796a         | Fixed fee  | 0.001 ETH          |            |
-| Bison Percentage-based   | 0x7a26BAC81b453E4d6407b8e3fD7989cF650dCABd       | Percentage | 1 BPS (or 0.01%)   |            |
+| Sepolia Fixed                   | [0x356B7B3C25355325CcBFBCF00a82895F93f086b7](https://sepolia.etherscan.io/address/0x356B7B3C25355325CcBFBCF00a82895F93f086b7)                                                                                                                                  | Fixed fee  | 0.001 ETH          |            |
+| Sepolia Percentage-based        | [0xDDa14370765696cD64bA93b974a934FF18A278e2](https://sepolia.etherscan.io/address/0xDDa14370765696cD64bA93b974a934FF18A278e2)        | Percentage | 10 BPS (or 0.1%)   |            |
+| Cronos-Testnet Fixed            | [0x1afc317C3C8578274B557a022aD79e073ef6EBF7](https://explorer.cronos.org/testnet/address/0x1afc317C3C8578274B557a022aD79e073ef6EBF7) | Fixed fee  | 0.001 ETH          |            |
+| Cronos-Testnet Percentage-based | [0xC5244700904c987E5441F568440ed5c3b7233559](https://explorer.cronos.org/testnet/address/0xC5244700904c987E5441F568440ed5c3b7233559) | Percentage | 1 BPS (or 0.01%)   |            |
+| Holesky Fixed                   | [0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef](https://holesky.etherscan.io/address/0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef)        | Fixed fee  | 0.001 ETH          |            |
+| Holesky Percentage-based        | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://holesky.etherscan.io/address/0xa477963806167acB38830Ea91B081a3de47B6ce9)        | Percentage | 1 BPS (or 0.01%)   |            |
+| Arbitrum-Sepolia Fixed          | [0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a](https://sepolia.arbiscan.io/address/0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a)         | Fixed fee  | 0.001 ETH          |            |
+| Gnosis-Chiado Fixed             | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://gnosis-chiado.blockscout.com/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a)| Fixed fee  | 0.001 xDAI         |            |
+| Base sepolia Fixed              | [0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a](https://sepolia.basescan.org/address/0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a)        | Fixed fee  | 0.001 ETH          |            |
+| Base sepolia Percentage-based   | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://sepolia.basescan.org/address/0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746)        | Percentage | 1 BPS (or 0.01%)   |            |
+| Amoy Fixed              | [0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7](https://www.oklink.com/amoy/address/0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7)        | Fixed fee  | 0.001 ETH          |            |
+| Amoy Percentage-based   | [0x2E3d3b2535785341584D17840F59dc0370b3504D](https://www.oklink.com/amoy/address/0x2E3d3b2535785341584D17840F59dc0370b3504D)        | Percentage | 1 BPS (or 0.01%)   |            |
+| B3 Sepolia Fixed   | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://sepolia.explorer.b3.fun/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a)         | Fixed fee  | 0.001 ETH          |            |
+| B3 Sepolia Percentage-based   | [0xA6Cd2A4c41946fAADACf88a87A50997B04abE557](https://sepolia.explorer.b3.fun/address/0xA6Cd2A4c41946fAADACf88a87A50997B04abE557)        | Percentage | 1 BPS (or 0.01%)   |            |
 
 
 ## Sygma Explorer

--- a/docs/08-resources/01-environments/03-testnet/index.md
+++ b/docs/08-resources/01-environments/03-testnet/index.md
@@ -57,8 +57,8 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Fee Router                     | [0xD277478b4684Ed8594d5eb5B228AA7aDbA59df43](https://sepolia.etherscan.io/address/0xD277478b4684Ed8594d5eb5B228AA7aDbA59df43) | [0xC2C26789671ec5e1542308Ee38faE4A640bCc03e](https://sepolia.etherscan.io/address/0xC2C26789671ec5e1542308Ee38faE4A640bCc03e) |
 | Fixed Fee Handler              | [0x356B7B3C25355325CcBFBCF00a82895F93f086b7](https://sepolia.etherscan.io/address/0x356B7B3C25355325CcBFBCF00a82895F93f086b7) | [0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C](https://sepolia.etherscan.io/address/0xEA3a9Bcc6de765aC6E01e327D22DB53b8d3DFa0C) |
 | Percentage Fee Handler         | [0xDDa14370765696cD64bA93b974a934FF18A278e2](https://sepolia.etherscan.io/address/0xDDa14370765696cD64bA93b974a934FF18A278e2) | [0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0](https://sepolia.etherscan.io/address/0xA048Ddc2C953052835e7847d8c3C4b19183AE1C0) |
-| Dynamic Fee Handler         | [0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37](https://sepolia.etherscan.io/address/0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37) |
-| Dynamic Fee Handler         | [0x52C09318436d729c212B582A0b2Aba2952da0a05](https://sepolia.etherscan.io/address/0x52C09318436d729c212B582A0b2Aba2952da0a05) |
+| Dynamic Native Token Fee Handler         | [0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37](https://sepolia.etherscan.io/address/0x6a5c39db255D55F77ccA590418EB4175Ec02Ea37) |
+| Dynamic GMP Fee Handler         | [0x52C09318436d729c212B582A0b2Aba2952da0a05](https://sepolia.etherscan.io/address/0x52C09318436d729c212B582A0b2Aba2952da0a05) |
 | ERC-20 Handler                 | [0xa65387feCb172ffF8A0aabA323A10c63757BBFA6](https://sepolia.etherscan.io/address/0xa65387feCb172ffF8A0aabA323A10c63757BBFA6) | [0x65Ce12864941F56D3665bb0d97D803E81a1d09a0](https://sepolia.etherscan.io/address/0x65Ce12864941F56D3665bb0d97D803E81a1d09a0) |
 | ERC-721 Handler                | [0x669F52487ffA6f9aBf722082f735537A98Ec0E4b](https://sepolia.etherscan.io/address/0x669F52487ffA6f9aBf722082f735537A98Ec0E4b) |                                                                                                                               |
 | ERC-1155 Handler               | [0x65903772866e538e6ffc001dd0c7665e356eb6d8](https://sepolia.etherscan.io/address/0x65903772866e538e6ffc001dd0c7665e356eb6d8) |                                                                                                                               |
@@ -78,7 +78,7 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Fee Router                        | [0xFaa9214b2bb90222c4f5A2DAbBB61fC945CDFD42](https://explorer.cronos.org/testnet/address/0xFaa9214b2bb90222c4f5A2DAbBB61fC945CDFD42) |
 | Fixed Fee Handler                 | [0x1afc317C3C8578274B557a022aD79e073ef6EBF7](https://explorer.cronos.org/testnet/address/0x1afc317C3C8578274B557a022aD79e073ef6EBF7) |
 | Percentage Fee Handler            | [0xC5244700904c987E5441F568440ed5c3b7233559](https://explorer.cronos.org/testnet/address/0xC5244700904c987E5441F568440ed5c3b7233559) |
-| ERC-20 Handler                    | [0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7](https://explorer.cronos.org/testnet/address/0x41F7869E4E0dd06c0c02804e4afcFA76BEE92CC7) |
+| ERC-20 Handler                    | [0x39D1Aea5F01138940F19A15049E2073D4df1dc9E](https://explorer.cronos.org/testnet/address/0x39D1Aea5F01138940F19A15049E2073D4df1dc9E) |
 | ERC-721 Handler                   | [0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a](https://explorer.cronos.org/testnet/address/0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a) |
 | ERC-1155 Handler                  | [0x2d92a0aa3ea19da735514ea542438345ef09cb60](https://explorer.cronos.org/testnet/address/0x2d92a0aa3ea19da735514ea542438345ef09cb60) |
 | Permissionless Generic Handler    | [0x3CBbC542d10CD037cafb1632B29B5B0F59B08A48](https://explorer.cronos.org/testnet/address/0x3CBbC542d10CD037cafb1632B29B5B0F59B08A48) |
@@ -88,11 +88,11 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 
 | Contract                       | MPC Address                                                                                                                   | Spectre Address                                                                                                               |
 |--------------------------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| Bridge                         | [0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a](https://holesky.etherscan.io/address/0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a) | [0x3DA376947B760836905a0407588C606D1020C4f3](https://holesky.etherscan.io/address/0x3DA376947B760836905a0407588C606D1020C4f3) |
+| Bridge                         | [0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78](https://holesky.etherscan.io/address/0xE366E0B707FBF59CF9A3068af34dC519D5fa6e78) | [0x3DA376947B760836905a0407588C606D1020C4f3](https://holesky.etherscan.io/address/0x3DA376947B760836905a0407588C606D1020C4f3) |
 | Fee Router                     | [0xfc8fE2bC5C780ef8cA28dda09751ef69BdDA53Cb](https://holesky.etherscan.io/address/0xfc8fE2bC5C780ef8cA28dda09751ef69BdDA53Cb) | [0x48512523Bb2634467292dd7776313916425F4c8a](https://holesky.etherscan.io/address/0x48512523Bb2634467292dd7776313916425F4c8a) |
 | Fixed Fee Handler              | [0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef](https://holesky.etherscan.io/address/0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef) | [0x51b9DcAcB395B00857C815aDb89D20175cBb4A58](https://holesky.etherscan.io/address/0x51b9DcAcB395B00857C815aDb89D20175cBb4A58) |
 | Percentage Fee Handler         | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://holesky.etherscan.io/address/0xa477963806167acB38830Ea91B081a3de47B6ce9) | [0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1](https://holesky.etherscan.io/address/0x8fc170823A8dc9eD6Ce81128f0FED3E0089D52f1) |
-| ERC-20 Handler                 | [0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F](https://holesky.etherscan.io/address/0x9D5C332Ebe0DaE36e07a4eD552Ad4d8c5067A61F) | [0x96e0cBCb653448a6AE76C2f4041eC6D73127585a](https://holesky.etherscan.io/address/0x96e0cBCb653448a6AE76C2f4041eC6D73127585a) |
+| ERC-20 Handler                 | [0xEeFBd08769Ab1e369a04a17180E91E4549938d4c](https://holesky.etherscan.io/address/0xEeFBd08769Ab1e369a04a17180E91E4549938d4c) | [0x96e0cBCb653448a6AE76C2f4041eC6D73127585a](https://holesky.etherscan.io/address/0x96e0cBCb653448a6AE76C2f4041eC6D73127585a) |
 | ERC-721 Handler                |                                                                                                                               |                                                                                                                               |
 | Permissionless Generic Handler | [0xc1154781Fa12a845aCaf276Bf2030040Ba9DAec8](https://holesky.etherscan.io/address/0xc1154781Fa12a845aCaf276Bf2030040Ba9DAec8) | [0x347BfeA6B3E929d91caE8e0AfB5DE97d3574AB45](https://holesky.etherscan.io/address/0x347BfeA6B3E929d91caE8e0AfB5DE97d3574AB45) |
 | Storage (GMP testing contract) | [0x58476c75b48c86c05ccad9ae82ac76145bc9119d](https://holesky.etherscan.io/address/0x58476c75b48c86c05ccad9ae82ac76145bc9119d) |                                                                                                                               |
@@ -121,8 +121,8 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | --------------------------------- | ------------------------------------------ |
 | Bridge                            | [0x668fad90DeAd0F8f04346A735875b62eF9c65f0B](https://gnosis-chiado.blockscout.com/address/0x668fad90DeAd0F8f04346A735875b62eF9c65f0B) |
 | Fee Router                        | [0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E](https://gnosis-chiado.blockscout.com/address/0x36930B9117713EF92E2f5Ca4FCa047DAdb92C48E) |
-| Fixed Fee Handler                 | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://gnosis-chiado.blockscout.com/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a) |
-| Percentage Fee Handler            | [0xA6Cd2A4c41946fAADACf88a87A50997B04abE557](https://gnosis-chiado.blockscout.com/address/0xA6Cd2A4c41946fAADACf88a87A50997B04abE557) |
+| Fixed Fee Handler                 | [0x27284B791992a40D18197087477304368Ac67Fcb](https://gnosis-chiado.blockscout.com/address/0x27284B791992a40D18197087477304368Ac67Fcb) |
+| Percentage Fee Handler            | [0x14d1cA88277E13B5615C2C727415a1B94E90264F](https://gnosis-chiado.blockscout.com/address/0x14d1cA88277E13B5615C2C727415a1B94E90264F) |
 | ERC-20 Handler                    | [0xb947F89269F0cF54CC721BcDE298a46930f3418b](https://gnosis-chiado.blockscout.com/address/0xb947F89269F0cF54CC721BcDE298a46930f3418b) |
 | Permissionless Generic Handler    | [0xe4B86b1B07bBdB0C47940b9B3bD4954A0deAdaBE](https://gnosis-chiado.blockscout.com/address/0xe4B86b1B07bBdB0C47940b9B3bD4954A0deAdaBE) |
 | Storage (GMP testing contract)    | [0x38ee9a4590035fc9506600f4d5c3f75fc8d15406](https://gnosis-chiado.blockscout.com/address/0x38ee9a4590035fc9506600f4d5c3f75fc8d15406) |
@@ -144,14 +144,14 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 
 | Contract                          | Address                                    |
 | --------------------------------- | ------------------------------------------ |
-| Bridge                            | [0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e](https://www.oklink.com/amoy/0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e) |
-| Fee Router                        | [0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6](https://www.oklink.com/amoy/0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6) |
-| Fixed Fee Handler                 | [0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7](https://www.oklink.com/amoy/0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7) |
-| Percentage Fee Handler            | [0x2E3d3b2535785341584D17840F59dc0370b3504D](https://www.oklink.com/amoy/0x2E3d3b2535785341584D17840F59dc0370b3504D) |
-| ERC-20 Handler                    | [0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af](https://www.oklink.com/amoy/0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af) |
-| Permissionless Generic Handler    | [0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7](https://www.oklink.com/amoy/0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7) |
-| Permissionless Generic Handler    | [0x1F932B2582c52f939DCfb367A3A42f8A95f66782](https://www.oklink.com/amoy/0x1F932B2582c52f939DCfb367A3A42f8A95f66782) |
-| Storage (GMP testing contract)    | [0x76b6fa3a0165f79aab9918e6193acb9e3bde5cdb](https://www.oklink.com/amoy/0x76b6fa3a0165f79aab9918e6193acb9e3bde5cdb) |
+| Bridge                            | [0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e](https://www.oklink.com/amoy/address/0x09379198A26E98b42E2619D2fCa1f3170c6FBB6e/contract) |
+| Fee Router                        | [0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6](https://www.oklink.com/amoy/address/0x04C4B75084B557ab0E79dE3DEd42b6c1dD4F48E6/contract) |
+| Fixed Fee Handler                 | [0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7](https://www.oklink.com/amoy/address/0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7/contract) |
+| Percentage Fee Handler            | [0x2E3d3b2535785341584D17840F59dc0370b3504D](https://www.oklink.com/amoy/address/0x2E3d3b2535785341584D17840F59dc0370b3504D/contract) |
+| ERC-20 Handler                    | [0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af](https://www.oklink.com/amoy/address/0x7E462Fc0E0b6f5EC18C8935f2676E7E40e06a7af/contract) |
+| Permissionless Generic Handler    | [0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7](https://www.oklink.com/amoy/address/0x3080Ecd6dEc3fe8a3A07d40e656f7D5fc6b3c3A7/contract) |
+| Permissionless Generic Handler    | [0x1F932B2582c52f939DCfb367A3A42f8A95f66782](https://www.oklink.com/amoy/address/0x1F932B2582c52f939DCfb367A3A42f8A95f66782/contract) |
+| Storage (GMP testing contract)    | [0x76b6fa3a0165f79aab9918e6193acb9e3bde5cdb](https://www.oklink.com/amoy/address/0x76b6fa3a0165f79aab9918e6193acb9e3bde5cdb/contract) |
 
 #### B3 Sepolia
 | Contract                          | Address                                    |
@@ -248,7 +248,7 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Bridging Strategy             | Lock/Release                                                                                                                            |
 | Resource ID                   | 0x0000000000000000000000000000000000000000000000000000000000000700                                                                   |
 | Sepolia Contract Address      | [0xc3cb14a020319f479ff164485008896a853dc8ca](https://sepolia.etherscan.io/address/0xc3cb14a020319f479ff164485008896a853dc8ca)        |
-| Holsky Contract Address       | [0x34d4fb8c45060143d39b7526c2b645d351af85a5](https://holesky.etherscan.io/address/0x34d4fb8c45060143d39b7526c2b645d351af85a5)         |
+| Holesky Contract Address       | [0x34d4fb8c45060143d39b7526c2b645d351af85a5](https://holesky.etherscan.io/address/0x34d4fb8c45060143d39b7526c2b645d351af85a5)         |
 
 
 ## Fee Schemes
@@ -262,7 +262,7 @@ The [faucet UI](./01-obtain-testnet-tokens.md "mention") provides users with a v
 | Holesky Fixed                   | [0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef](https://holesky.etherscan.io/address/0xd6224d509DDa6c5eB3FFd3204218AD8eEC8F59Ef)        | Fixed fee  | 0.001 ETH          |            |
 | Holesky Percentage-based        | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://holesky.etherscan.io/address/0xa477963806167acB38830Ea91B081a3de47B6ce9)        | Percentage | 1 BPS (or 0.01%)   |            |
 | Arbitrum-Sepolia Fixed          | [0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a](https://sepolia.arbiscan.io/address/0x2D7651aF6FFdb486571067568BFefA6e7fe7Fa8a)         | Fixed fee  | 0.001 ETH          |            |
-| Gnosis-Chiado Fixed             | [0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a](https://gnosis-chiado.blockscout.com/address/0x8651f04eFA1FccfB9Cd27c6FE3FA0F2E7CB7A75a)| Fixed fee  | 0.001 xDAI         |            |
+| Gnosis-Chiado Fixed             | [0x27284B791992a40D18197087477304368Ac67Fcb](https://gnosis-chiado.blockscout.com/address/0x27284B791992a40D18197087477304368Ac67Fcb)| Fixed fee  | 0.001 xDAI         |            |
 | Base sepolia Fixed              | [0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a](https://sepolia.basescan.org/address/0x52757D9c1a8f8b496cf1e688bbB8055f9F3DfC8a)        | Fixed fee  | 0.001 ETH          |            |
 | Base sepolia Percentage-based   | [0xa477963806167acB38830Ea91B081a3de47B6ce9](https://sepolia.basescan.org/address/0x8b8F51bB26Eb521ac33dD6DcAA97f5d052977746)        | Percentage | 1 BPS (or 0.01%)   |            |
 | Amoy Fixed              | [0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7](https://www.oklink.com/amoy/address/0x5842071a7D59e56c73874194A1Ea25FcFB6e00D7)        | Fixed fee  | 0.001 ETH          |            |


### PR DESCRIPTION
### Description
- removed bison testnet
- updated feeRouter and feeHandler addresses
- updated gmp handler on b3-sepolia
- updated resources

For the reference, [this](https://app.zenhub.com/workspaces/sygma-protocol-62f126a54b7d5a55203732f0/issues/gh/sygmaprotocol/devops/476) are the new changes