### PR TITLE
chore: substrate testnet notification

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -480,3 +480,4 @@ MAINNET
 sygma-props
 SygmaProtocolReactWidget
 setState
+Paseo

--- a/docs/03-sygma-sdk/04-Examples/01-Basic-ERC-20-Token-Transfers/02-EVM-Substrate-example.md
+++ b/docs/03-sygma-sdk/04-Examples/01-Basic-ERC-20-Token-Transfers/02-EVM-Substrate-example.md
@@ -7,6 +7,10 @@ sidebar_position: 2
 draft: false
 ---
 
+:::warning
+Please be aware that the Rococo-Phala testnet is currently down due to ongoing maintenance by the Phala team as they migrate their testnet to Paseo. Stay tuned for further updates.
+:::
+
 ### EVM-to-Substrate token transfer example
 
 In the following example, we will use the `TESTNET` environment to perform a cross-chain ERC-20 transfer with 0.5 Sepolia sygUSD `sygUSD` tokens. The transfer will be initiated on the EVM-side via the Sepolia Ethereum testnet and received on the Substrate-side via the Rococo-Phala testnet.

--- a/docs/03-sygma-sdk/04-Examples/01-Basic-ERC-20-Token-Transfers/03-Substrate-EVM-example.md
+++ b/docs/03-sygma-sdk/04-Examples/01-Basic-ERC-20-Token-Transfers/03-Substrate-EVM-example.md
@@ -7,6 +7,11 @@ sidebar_position: 3
 draft: false
 ---
 
+:::warning
+Please be aware that the Rococo-Phala testnet is currently down due to ongoing maintenance by the Phala team as they migrate their testnet to Paseo. Stay tuned for further updates.
+:::
+
+
 ### EVM-to-Substrate token transfer example
 
 In the following example, we will use the `TESTNET` environment to perform a cross-chain ERC-20 transfer with 0.5 sygUSD `sygUSD` tokens. The transfer will be initiated on the Substrate-side via the Rococo-Phala testnet and received on the EVM-side via the Sepolia Ethereum testnet.


### PR DESCRIPTION
@freddyli7 notified that the rococo-phala testnet is currently down due to phala's migration to the paseo testnet. just adding blurbs where i can.